### PR TITLE
add indicators

### DIFF
--- a/src/ModelEditPlugin/EditableModelBase.h
+++ b/src/ModelEditPlugin/EditableModelBase.h
@@ -17,7 +17,7 @@
 
 namespace cnoid {
 
-class CNOID_EXPORT EditableModelBase
+class CNOID_EXPORT EditableModelBase : public Item
 {
 public:
     EditableModelBase();

--- a/src/ModelEditPlugin/JointItem.cpp
+++ b/src/ModelEditPlugin/JointItem.cpp
@@ -73,6 +73,7 @@ public:
     SgScaleTransformPtr defaultAxesScale;
     SgMaterialPtr axisMaterials[3];
     double axisCylinderNormalizedRadius;
+    SgPosTransformPtr axisShape;
 
     //ModelEditDraggerPtr positionDragger;
     PositionDraggerPtr positionDragger;
@@ -302,6 +303,34 @@ void JointItemImpl::onUpdated()
 {
     sceneLink->translation() = self->translation;
     sceneLink->rotation() = self->rotation;
+
+    // draw shape indicator for joint axis
+    if (axisShape) {
+        sceneLink->removeChild(axisShape);
+        axisShape = NULL;
+    }
+    string jt(jointType.selectedSymbol());
+    if (jt != "free" && jt != "fixed") {
+        axisShape = new SgPosTransform;
+        SgShapePtr shape = new SgShape;
+        SgMaterialPtr material = new SgMaterial;
+        material->setDiffuseColor(Vector3f(1.0f, 0.0f, 0.0f));
+        material->setEmissiveColor(Vector3f::Zero());
+        material->setAmbientIntensity(0.0f);
+        material->setTransparency(0.0f);
+        MeshGenerator meshGenerator;
+        SgMeshPtr mesh = meshGenerator.generateDisc(0.15, 0.12);
+        shape->setMesh(mesh);
+        shape->setMaterial(material);
+        axisShape->addChild(shape);
+        if (jointAxis[0] == 0 && jointAxis[1] == 1 && jointAxis[2] == 0) {
+            axisShape->setRotation(AngleAxis( PI / 2.0, Vector3::UnitX()));
+        }
+        if (jointAxis[0] == 0 && jointAxis[1] == 0 && jointAxis[2] == 1) {
+            axisShape->setRotation(AngleAxis(-PI / 2.0, Vector3::UnitZ()));
+        }
+        sceneLink->addChildOnce(axisShape);
+    }
     sceneLink->notifyUpdate();
 }
 

--- a/src/ModelEditPlugin/JointItem.h
+++ b/src/ModelEditPlugin/JointItem.h
@@ -20,7 +20,7 @@ class JointItem;
 typedef ref_ptr<JointItem> JointItemPtr;
 class JointItemImpl;
 
-class CNOID_EXPORT JointItem : public Item, public SceneProvider, public EditableModelBase
+class CNOID_EXPORT JointItem : public SceneProvider, public EditableModelBase
 {
 public:
     static void initializeClass(ExtensionManager* ext);

--- a/src/ModelEditPlugin/LinkItem.cpp
+++ b/src/ModelEditPlugin/LinkItem.cpp
@@ -66,6 +66,7 @@ public:
     SgNode* mesh;
     SgShape* shape;
 
+    Vector3 dragStartTranslation;
     //ModelEditDraggerPtr positionDragger;
     PositionDraggerPtr positionDragger;
 
@@ -140,7 +141,7 @@ LinkItemImpl::LinkItemImpl(LinkItem* self, Link* link)
 
 
 LinkItem::LinkItem(const LinkItem& org)
-    : Item(org)
+    : EditableModelBase(org)
 {
     impl = new LinkItemImpl(this, *org.impl);
 }
@@ -253,6 +254,7 @@ void LinkItemImpl::onSelectionChanged()
 
 void LinkItemImpl::onDraggerStarted()
 {
+    dragStartTranslation = positionDragger->draggedPosition().translation();
 }
 
 

--- a/src/ModelEditPlugin/LinkItem.cpp
+++ b/src/ModelEditPlugin/LinkItem.cpp
@@ -62,9 +62,11 @@ public:
     Matrix3 momentsOfInertia;
     bool isselected;
 
-    SgPosTransform* sceneLink;
+    SceneLink* sceneLink;
     SgNode* mesh;
     SgShape* shape;
+    SgPosTransformPtr massShape;
+    bool visualizeMass;
 
     Vector3 dragStartTranslation;
     //ModelEditDraggerPtr positionDragger;
@@ -189,6 +191,8 @@ void LinkItemImpl::init()
     self->translation = link->translation();
     self->rotation = link->rotation();
     sceneLink = new SceneLink(link);
+    massShape = NULL;
+    visualizeMass = false;
 
     if(self->name().size() == 0){
         SgGroup* group = dynamic_cast<SgGroup*>(link->shape());
@@ -269,6 +273,48 @@ void LinkItemImpl::onUpdated()
 {
     sceneLink->translation() = self->translation;
     sceneLink->rotation() = self->rotation;
+    
+    // draw shape indicator for mass
+    if (massShape) {
+        sceneLink->removeChild(massShape);
+        massShape = NULL;
+    }
+    if (visualizeMass) {
+        // hide original mesh
+        sceneLink->setVisible(false);
+        // generate CoM ball
+        massShape = new SgPosTransform;
+        SgShapePtr shape = new SgShape;
+        SgMaterialPtr commaterial = new SgMaterial;
+        commaterial->setDiffuseColor(Vector3f(1.0f, 0.0f, 0.0f));
+        commaterial->setEmissiveColor(Vector3f::Zero());
+        commaterial->setAmbientIntensity(0.0f);
+        commaterial->setTransparency(0.0f);
+        MeshGenerator meshGenerator;
+        SgMeshPtr mesh = meshGenerator.generateSphere(0.02);
+        shape->setMesh(mesh);
+        shape->setMaterial(commaterial);
+        massShape->addChild(shape);
+        // generate inertia shape
+        SgShapePtr inertshape = new SgShape;
+        SgScaleTransformPtr inertscale = new SgScaleTransform;
+        SgMaterialPtr inertmaterial = new SgMaterial;
+        inertmaterial->setDiffuseColor(Vector3f(0.0f, 0.0f, 1.0f));
+        inertmaterial->setEmissiveColor(Vector3f::Zero());
+        inertmaterial->setAmbientIntensity(0.0f);
+        inertmaterial->setTransparency(0.5f);
+        SgMeshPtr inertmesh = meshGenerator.generateSphere(1);
+        inertshape->setMesh(inertmesh);
+        inertshape->setMaterial(inertmaterial);
+        inertscale->addChild(inertshape);
+        inertscale->setScale(Vector3(momentsOfInertia(0,0), momentsOfInertia(1,1), momentsOfInertia(2,2)));
+        massShape->addChild(inertscale);
+        
+        massShape->setTranslation(centerOfMass);
+        sceneLink->addChildOnce(massShape);
+    } else {
+        sceneLink->setVisible(true);
+    }
     sceneLink->notifyUpdate();
 }
 
@@ -422,6 +468,7 @@ void LinkItemImpl::doPutProperties(PutPropertyFunction& putProperty)
     oss << momentsOfInertia;
     putProperty(_("Inertia"), oss.str(),
                 boost::bind(&LinkItemImpl::setInertia, this, _1));
+    putProperty.decimals(4)(_("Visualize mass"), visualizeMass, changeProperty(visualizeMass));
 }
 
 

--- a/src/ModelEditPlugin/LinkItem.h
+++ b/src/ModelEditPlugin/LinkItem.h
@@ -20,7 +20,7 @@ class LinkItem;
 typedef ref_ptr<LinkItem> LinkItemPtr;
 class LinkItemImpl;
 
-class CNOID_EXPORT LinkItem : public Item, public SceneProvider, public EditableModelBase
+class CNOID_EXPORT LinkItem : public SceneProvider, public EditableModelBase
 {
 public:
     static void initializeClass(ExtensionManager* ext);

--- a/src/ModelEditPlugin/PrimitiveShapeItem.cpp
+++ b/src/ModelEditPlugin/PrimitiveShapeItem.cpp
@@ -139,7 +139,7 @@ PrimitiveShapeItemImpl::PrimitiveShapeItemImpl(PrimitiveShapeItem* self, Link* l
     
 
 PrimitiveShapeItem::PrimitiveShapeItem(const PrimitiveShapeItem& org)
-    : Item(org)
+    : EditableModelBase(org)
 {
     impl = new PrimitiveShapeItemImpl(this, *org.impl);
 }

--- a/src/ModelEditPlugin/PrimitiveShapeItem.h
+++ b/src/ModelEditPlugin/PrimitiveShapeItem.h
@@ -21,7 +21,7 @@ class PrimitiveShapeItem;
 typedef ref_ptr<PrimitiveShapeItem> PrimitiveShapeItemPtr;
 class PrimitiveShapeItemImpl;
 
-class CNOID_EXPORT PrimitiveShapeItem : public Item, public SceneProvider, public EditableModelBase
+class CNOID_EXPORT PrimitiveShapeItem : public SceneProvider, public EditableModelBase
 {
 public:
     static void initializeClass(ExtensionManager* ext);

--- a/src/ModelEditPlugin/SensorItem.cpp
+++ b/src/ModelEditPlugin/SensorItem.cpp
@@ -153,7 +153,7 @@ SensorItemImpl::SensorItemImpl(SensorItem* self, Device* dev)
 
 
 SensorItem::SensorItem(const SensorItem& org)
-    : Item(org)
+    : EditableModelBase(org)
 {
     impl = new SensorItemImpl(this, *org.impl);
 }

--- a/src/ModelEditPlugin/SensorItem.h
+++ b/src/ModelEditPlugin/SensorItem.h
@@ -21,7 +21,7 @@ class SensorItem;
 typedef ref_ptr<SensorItem> SensorItemPtr;
 class SensorItemImpl;
 
-class CNOID_EXPORT SensorItem : public Item, public SceneProvider, public EditableModelBase
+class CNOID_EXPORT SensorItem : public SceneProvider, public EditableModelBase
 {
 public:
     static void initializeClass(ExtensionManager* ext);


### PR DESCRIPTION
前のままだとどうにもドキュメントを書くのが難しかったので、関節軸の視覚化、カメラの視覚化、リンクの重心と慣性の視覚化を追加しました。

また、関節をドラッグした際に小アイテムもついてくるようにしました。