### PR TITLE
Windowsで使用した際に発生した不具合に関する変更・修正

### DIFF
--- a/src/ModelEditPlugin/EditableModelBase.h
+++ b/src/ModelEditPlugin/EditableModelBase.h
@@ -21,8 +21,8 @@ public:
     VRMLNodePtr originalNode;
     Vector3 translation, absTranslation;
     Matrix3 rotation, absRotation;
-    virtual VRMLNodePtr toVRML() {};
-    virtual std::string toURDF() {};
+    virtual VRMLNodePtr toVRML() { return NULL; };
+    virtual std::string toURDF() { return ""; };
     bool onTranslationChanged(const std::string& value);
     bool onRotationChanged(const std::string& value);
     bool onRotationAxisChanged(const std::string& value);

--- a/src/ModelEditPlugin/EditableModelItem.cpp
+++ b/src/ModelEditPlugin/EditableModelItem.cpp
@@ -271,9 +271,11 @@ void createShapeItems(LinkItem *linkItem, SgNode *snode, VRMLNode *vnode,
         SgGroup *group = dynamic_cast<SgGroup *>(snode);
         if (!group){
             std::cerr << "error(1) in createShapeItems" << std::endl;
+            return;
         }
         if (group->numChildren()!=1) {
             std::cerr << "error(2) in createShapeItems" << std::endl;
+            return;
         }
         SgPosTransform *strans = dynamic_cast<SgPosTransform *>(group->child(0));
         if (strans){ // This means link->Rs() is not identity matrix
@@ -281,15 +283,18 @@ void createShapeItems(LinkItem *linkItem, SgNode *snode, VRMLNode *vnode,
             rotation = rotation*strans->rotation();
             if (strans->numChildren() != 1){
                 std::cerr << "error(7) in createShapeItems" << std::endl;
+                return;
             }
             group = strans;
         }
         group = dynamic_cast<SgGroup *>(group->child(0));
         if (!group){
             std::cerr << "error(3) in createShapeItems" << std::endl;
+            return;
         }
         if (group->numChildren() != children.size()){
             std::cerr << "error(6) in createShapeItems" << std::endl;
+            return;
         }
         for (unsigned int i=0; i<children.size(); i++){
             createShapeItems(linkItem, group->child(i), children[i].get(), translation, rotation);
@@ -303,9 +308,11 @@ void createShapeItems(LinkItem *linkItem, SgNode *snode, VRMLNode *vnode,
         SgPosTransform *strans = dynamic_cast<SgPosTransform *>(snode);
         if (!strans){
             std::cerr << "error(4) in createShapeItems" << std::endl;
+            return;
         }
         if (vtrans->countChildren() != strans->numChildren()){
             std::cerr << "error(5) in createShapeItems" << std::endl;
+            return;
         }
         translation = rotation*strans->translation() + translation;
         rotation = rotation*strans->rotation();
@@ -322,6 +329,7 @@ void createShapeItems(LinkItem *linkItem, SgNode *snode, VRMLNode *vnode,
         SgShape *sshape = dynamic_cast<SgShape *>(snode);
         if (!sshape){
             std::cerr << "error in createShapeItems" << std::endl;
+            return;
         }
         SgMesh *mesh = sshape->mesh();
         if (mesh->primitiveType() != SgMesh::MESH){

--- a/src/ModelEditPlugin/EditableModelItem.cpp
+++ b/src/ModelEditPlugin/EditableModelItem.cpp
@@ -482,6 +482,8 @@ bool EditableModelItemImpl::saveModelFile(const std::string& filename)
 
     writer->writeOpenHRPPROTOs();
     writer->writeNode(toVRML());
+
+    return true;
 }
 
 
@@ -497,6 +499,7 @@ bool EditableModelItemImpl::saveModelFileURDF(const std::string& filename)
     of.open(filename.c_str(), std::ios::out);
     of << toURDF();
     of.close();
+    return true;
 }
 
 
@@ -516,6 +519,7 @@ bool EditableModelItemImpl::saveModelFileSDF(const std::string& filename)
     of << robot->ToString();
     cout << robot->ToString() << endl;
     of.close();
+    return true;
 }
 
 

--- a/src/ModelEditPlugin/JointItem.cpp
+++ b/src/ModelEditPlugin/JointItem.cpp
@@ -36,7 +36,7 @@ class JointItemImpl
 {
 public:
     JointItem* self;
-    Link* link;
+    LinkPtr link;
     int jointId;
     Selection jointType;
     Vector3 jointAxis;

--- a/src/ModelEditPlugin/LinkItem.cpp
+++ b/src/ModelEditPlugin/LinkItem.cpp
@@ -39,7 +39,7 @@ class LinkItemImpl
 {
 public:
     LinkItem* self;
-    Link* link;
+    LinkPtr link;
     double mass;
     Vector3 centerOfMass;
     Matrix3 momentsOfInertia;

--- a/src/ModelEditPlugin/LinkItem.cpp
+++ b/src/ModelEditPlugin/LinkItem.cpp
@@ -255,7 +255,7 @@ void LinkItemImpl::onUpdated()
         sceneLink->setVisible(false);
         // generate CoM ball
         massShape = new SgPosTransform;
-        SgShapePtr shape = new SgShape;
+        shape = new SgShape;
         SgMaterialPtr commaterial = new SgMaterial;
         commaterial->setDiffuseColor(Vector3f(1.0f, 0.0f, 0.0f));
         commaterial->setEmissiveColor(Vector3f::Zero());

--- a/src/ModelEditPlugin/PrimitiveShapeItem.cpp
+++ b/src/ModelEditPlugin/PrimitiveShapeItem.cpp
@@ -296,7 +296,7 @@ void PrimitiveShapeItemImpl::onUpdated()
         sceneLink->removeChild(shape);
         shape = NULL;
     }
-    SgShape *shape = new SgShape;
+    shape = new SgShape;
     SgMaterial* material = new SgMaterial;
     material->setDiffuseColor(primitiveColor);
     material->setEmissiveColor(Vector3f::Zero());


### PR DESCRIPTION
Windowsで使用していた際にいくつか不具合が発生したため、いくつか変更・修正を行いました。

１. 値を返していない関数があったためビルドに失敗する

VC++の場合は値を返さない関数があるとエラーになるので値を返すように変更しました。

２. PrimitiveShapeの大きさを変更した場合に シーンビューに変更前のShapeが残る

PrimitiveShapeItemクラスのメンバ変数shapeとonUpdated関数内のローカル変数の名前が同じであるため、おそらくメンバ変数のshapeを初期化したいのにローカル変数のshapeを初期化していることが原因だと思います。onUpdated関数内で変数shapeを新たに宣言する必要はなさそうなので修正しました。

３. ファイルからモデルを読み込み後、ツリーからJointItemをコピーしようとするとプロセスが異常終了する

EditableModelItemImplクラスのloadModelFile関数内で変数newBodyが破棄される際に保持しているLinkオブジェクトも同時に破棄されます。JointItemでもLinkオブジェクトを保持しているのですがこれがスマートポインタではなくただのポインタで保持していため、すでに破棄されているとは知らずにアクセスしにいくことがあるようです。このためJointItemクラスの変数linkの型をLinkPtrに変更しました。
